### PR TITLE
fix: proper nindenting for config.env

### DIFF
--- a/charts/s3proxy/templates/deployment.yaml
+++ b/charts/s3proxy/templates/deployment.yaml
@@ -66,9 +66,9 @@ spec:
                 {{- end }}
                 key: AWS_SECRET_ACCESS_KEY
                 optional: false
-            {{- with .Values.config.env }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+          {{- with .Values.config.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
To allow injecting additional environment variables with the `config.env` value, the toYaml results need to be indented to the same depth as the other env variables.

Please let me know if this needs any additional changes like bumping the version in Chart.yaml or adding a DCO.