### PR TITLE
feat: configurable command and args for container

### DIFF
--- a/charts/s3proxy/templates/deployment.yaml
+++ b/charts/s3proxy/templates/deployment.yaml
@@ -37,14 +37,10 @@ spec:
           #checkov:skip=CKV_K8S_43: Not for Public Charts
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ['java']
+          command:
+            {{- .Values.command | toYaml | nindent 12 }}
           args:
-          - -Ds3proxy.identity=$(S3PROXY_IDENTITY)
-          - -Ds3proxy.credential=$(S3PROXY_CREDENTIAL)
-          - -jar
-          - /opt/s3proxy/s3proxy
-          - --properties
-          - /etc/s3proxy/s3proxy.properties
+            {{- .Values.args | toYaml | nindent 12 }}
           env:
           - name: S3PROXY_IDENTITY
             valueFrom:

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -10,6 +10,16 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+command:
+  - java
+args:
+  - -Ds3proxy.identity=$(S3PROXY_IDENTITY)
+  - -Ds3proxy.credential=$(S3PROXY_CREDENTIAL)
+  - -jar
+  - /opt/s3proxy/s3proxy
+  - --properties
+  - /etc/s3proxy/s3proxy.properties
+
 config:
   env: []
   s3proxy:


### PR DESCRIPTION
Hi, we're trying to deploy s3proxy to a cluster using Argo CD, but Argo CD doesn't currently support the lookup operator used in https://github.com/s3proxy-distro/helm-s3proxy/blob/74632d65fc59827a528f87c0b5b38edeb9ef6ce3/charts/s3proxy/templates/_secret.tpl#L33

To work around this, we're currently ignoring the generated properties file and specifying all setting via env variables. This change makes it possible to tweak the container's command and args allowing us to ensure that the properties file doesn't get used.

We considered refactoring the secrets template, but this change feels more pragmatic as a workaround given that we expect Argo CD to support the lookup operator in the future.